### PR TITLE
Get ready for 0.3.2 release revert to require jars

### DIFF
--- a/lib/jruby_art/app.rb
+++ b/lib/jruby_art/app.rb
@@ -7,6 +7,9 @@ require_relative '../jruby_art/config'
 
 # A wrapper module for the processing App
 module Processing
+  Dir[format("%s/core/library/\*.jar", RP_CONFIG['PROCESSING_ROOT'])].each do |jar| 
+    require jar unless jar =~ /native/
+  end
   # Include some core processing classes that we'd like to use:
   include_package 'processing.core'
   # Load vecmath and fastmath modules

--- a/lib/jruby_art/runner.rb
+++ b/lib/jruby_art/runner.rb
@@ -153,10 +153,6 @@ module Processing
 
     private
 
-    def core_classpath
-      Dir["#{Processing::RP_CONFIG['PROCESSING_ROOT']}/core/library/\*.jar"]
-    end
-
     # Trade in this Ruby instance for a JRuby instance, loading in a starter
     # script and passing it some arguments.Unless '--nojruby' is passed, the
     # installed version of jruby is used instead of our vendored jarred one
@@ -168,11 +164,10 @@ module Processing
       @options.nojruby = true if Processing::RP_CONFIG['JRUBY'] == 'false'
       java_args = discover_java_args(sketch)
       if @options.nojruby
-        classpath = jruby_complete + core_classpath + libraries
         command = ['java',
                    java_args,
                    '-cp',
-                   classpath.join(path_separator),
+                   jruby_complete,
                    'org.jruby.Main',
                    runner,
                    sketch,
@@ -180,8 +175,6 @@ module Processing
       else
         command = ['jruby',
                    java_args,
-                   '-J-cp',
-                   core_classpath.join(path_separator),
                    runner,
                    sketch,
                    args].flatten
@@ -191,10 +184,6 @@ module Processing
         # exec replaces the Ruby process with the JRuby one.
       rescue Java::JavaLang::ClassNotFoundException
       end
-    end
-
-    def path_separator
-      (host_os == :windows) ? ';' : ':'
     end
 
     # If you need to pass in arguments to Java, such as the ones on this page:

--- a/vendors/Rakefile
+++ b/vendors/Rakefile
@@ -8,7 +8,7 @@ WARNING = <<-EOS
       
 EOS
 
-JRUBYC_VERSION     = '9.0.0.0.rc2'
+JRUBYC_VERSION     = '9.0.0.0'
 EXAMPLES           = '0.2'
 HOME_DIR = ENV['HOME']
 MAC_OR_LINUX = /linux|mac|darwin/ =~ RbConfig::CONFIG['host_os'] 
@@ -27,7 +27,7 @@ file "jruby-complete-#{JRUBYC_VERSION}.jar" do
   rescue
     warn(WARNING)
   end
-  check_sha1("jruby-complete-#{JRUBYC_VERSION}.jar", "3c490d1b621db41709e0d093ab36585a50604dfd")
+  check_sha1("jruby-complete-#{JRUBYC_VERSION}.jar", "2479278bdd92d85ca37c5d45a4ec4745c50dfccb")
 end
 
 directory "../lib/ruby"


### PR DESCRIPTION
Since the release of jruby-9.0.0.0 it is better to require all jars than load some in java classpath and try require others later.