### PR TITLE
Set Stable To JRubyArt-0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+**v0.4.0** Update to jruby-9.0.0.0 we can revert to using require to load jars first release tested with processing-3.0a11 on linux
+
 
 **v0.3.1** Update to jruby-complete-9.0.0.0.rc2, add vector type access to Vec2D and Vec3D parameters eg `vector[:x]` to return 'x' value,  and `vector[:x] = 20` to assign value (also simplify the return type of assignment as input value).
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 [![Gem Version](https://badge.fury.io/rb/jruby_art.svg)](http://badge.fury.io/rb/jruby_art)
 
 ## Requirements
-A clean start for `jruby_art` based on processing-3.0 alpha and jruby-9.0.0.0, having difficulty with original JRubyArt and jruby-9000, also this might be the way to go retaining the ruby-processing good bits, with no legacy overhang. See [wiki](https://github.com/ruby-processing/JRubyArt/wiki/Building-latest-gem) for building gem from this repo.
+A clean start for `jruby_art` based on processing-3.0 alpha and jruby-9.0.0.0  [wiki](https://github.com/ruby-processing/JRubyArt/wiki/Building-latest-gem) for building gem from this repo.
 ## Requirements
  
-A suitable version of ruby (MRI ruby > 2.1 or latest `pre jruby-9.0.0.0.rc2+ SNAPSHOT` to download gem. *I had an issue with `jruby-9.0.0.0.rc1` rgem not being recognised as 2.1 compliant*
+A suitable version of ruby (MRI ruby > 2.1 or `jruby-9.0.0.0` to download gem. 
 
 `processing-3.0a11+`
 
-
-`jdk1.8.0_45+` can be openjdk with OpenJFX _a separate download works on ArchLinux_ probably save to go with the Oracle version
+`jdk1.8.0_51+` can be openjdk with OpenJFX _a separate download works on ArchLinux_ probably save to go with the Oracle version
 
 ### recommended installs (JRubyArt is currently hard-coded to expect them)
 
@@ -32,12 +31,12 @@ sketchbook_path: /home/tux/sketchbook
 Manually install jruby-complete-SNAPSHOT
 
 ```bash
- gem install jruby_art --pre
- # k9 setup install # installs jruby-complete-9.0.0.0.rc2
+ gem install jruby_art
+ # k9 setup install # installs jruby-complete-9.0.0.0
  k9 setup unpack_samples # downloads and installs samples to ~/k9_samples
  cd ~/k9_samples/contributed
- k9 --nojruby run jwishy.rb # unless you have jruby-9.0.0.0.rc2+ installed or config JRUBY: 'false'
- k9 run jwishy.rb # if you have jruby-9.0.0.0.rc2 installed or config JRUBY: 'false'
+ k9 --nojruby run jwishy.rb # unless you have jruby-9.0.0.0 installed or config JRUBY: 'false'
+ k9 run jwishy.rb # if you have jruby-9.0.0.0 installed or config JRUBY: 'false'
 ```
 ## Create sketches from built in templates
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 
 # size goes here since processing-3.0a10, the processing guys hide this
 # by doing pre-processing on the pde file (check the java output).
-# FX2D works better for me (on linux) than JAVA2D with Ben Fry current loop() kludge
+# FX2D (is in the works but not 100%) default is still JAVA2D
 def settings
   size 400, 300, FX2D
 end
@@ -71,11 +71,11 @@ end
 or
 `k9 --nojruby run sketch.rb`
 
-be prepared to KILL the odd java process (that doesn't exit cleanly all the time), watch seems now to work (but no easy way of disposing last window) failing
+be prepared to KILL the odd java process (that doesn't exit cleanly all the time), watch seems now to work
 
 ## Watch sketches
 ```bash
-k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mode
+k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mode during watch
 ```
 
 ## Example sketches

--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mo
 
 ## Conversion Tool
 
-I wrote this little script to convert sketches from ruby-processing (processing-2) to jruby_art (processing-3.0) [here](https://gist.github.com/monkstone/1a658bdda4ea21c204c5)
+I wrote this little script to convert sketches from ruby-processing (processing-2) to jruby_art (processing-3.0) [here](https://gist.github.com/monkstone/1a658bdda4ea21c204c5).
 
 That I used to convert The-Nature-of-Code-Examples-in-Ruby to [The-Nature-of-Code-Examples-for-JRubyArt](https://github.com/ruby-processing/The-Nature-of-Code-for-JRubyArt)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ sketchbook_path: /home/tux/sketchbook
 ```
 
 ## Install Steps (assumes you have requirements above) 
-Manually install jruby-complete-SNAPSHOT
 
 ```bash
  gem install jruby_art
- # k9 setup install # installs jruby-complete-9.0.0.0
+ k9 setup install # installs jruby-complete-9.0.0.0
  k9 setup unpack_samples # downloads and installs samples to ~/k9_samples
  cd ~/k9_samples/contributed
  k9 --nojruby run jwishy.rb # unless you have jruby-9.0.0.0 installed or config JRUBY: 'false'

--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mo
 
 I wrote this little script to convert sketches from ruby-processing (processing-2) to jruby_art (processing-3.0) [here](https://gist.github.com/monkstone/1a658bdda4ea21c204c5).
 
-That I used to convert The-Nature-of-Code-Examples-in-Ruby to [The-Nature-of-Code-Examples-for-JRubyArt](https://github.com/ruby-processing/The-Nature-of-Code-for-JRubyArt)
+See The-Nature-of-Code-Examples-in-Ruby converted to [The-Nature-of-Code-Examples-for-JRubyArt](https://github.com/ruby-processing/The-Nature-of-Code-for-JRubyArt) using the script.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mo
 
 ## Example sketches
 
-[Worked Examples](https://github.com/ruby-processing/samples4ruby-processing3) more to follow, feel free to add your own, especially ruby-2.1+ syntax now we can. These can now be downloaded using `k9 setup unpack_samples` please move existing rp_samples.
+[Worked Examples](https://github.com/ruby-processing/samples4ruby-processing3) more to follow, feel free to add your own, especially ruby-2.1+ syntax now we can. These can now be downloaded using `k9 setup unpack_samples` please move existing k9_samples.
 
 ## Conversion Tool
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ k9 watch sketch.rb # don't try and change render mode, or use the FX2D render mo
 
 I wrote this little script to convert sketches from ruby-processing (processing-2) to jruby_art (processing-3.0) [here](https://gist.github.com/monkstone/1a658bdda4ea21c204c5)
 
+That I used to convert The-Nature-of-Code-Examples-in-Ruby to [The-Nature-of-Code-Examples-for-JRubyArt](https://github.com/ruby-processing/The-Nature-of-Code-for-JRubyArt)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A suitable version of ruby (MRI ruby > 2.1 or `jruby-9.0.0.0` to download gem.
 
 `processing-3.0a11+`
 
-`jdk1.8.0_51+` can be openjdk with OpenJFX _a separate download works on ArchLinux_ probably save to go with the Oracle version
+`jdk1.8.0_51+` can be openjdk with OpenJFX _a separate download works on ArchLinux_ probably safer to go with the Oracle version
 
 ### recommended installs (JRubyArt is currently hard-coded to expect them)
 

--- a/jruby_art.gemspec
+++ b/jruby_art.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = "martin_p@lineone.net"
   spec.description = <<-EOS
   JRubyArt is a ruby wrapper for the processing art framework.
-  The current version supports processing-3.0a10, and uses jruby-9.0.0.0.rc2
+  The current version supports processing-3.0a11, and uses jruby-9.0.0.0
   as the glue between ruby and java. You can use both processing libraries and ruby
   gems in your sketches. Features create/run/watch modes. The "watch" mode,
   provides a nice REPL-ish way to work on your processing sketches. Includes:-
@@ -38,6 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.requirements << 'A decent graphics card'
   spec.requirements << 'java runtime >= 1.8+'
-  spec.requirements << 'processing = 3.0a10+'
+  spec.requirements << 'processing = 3.0a11+'
 end
-

--- a/lib/jruby_art/version.rb
+++ b/lib/jruby_art/version.rb
@@ -1,3 +1,3 @@
 module JRubyArt
-  VERSION = '0.3.1.pre'
+  VERSION = '0.4.0'
 end

--- a/vendors/Rakefile
+++ b/vendors/Rakefile
@@ -9,7 +9,7 @@ WARNING = <<-EOS
 EOS
 
 JRUBYC_VERSION     = '9.0.0.0'
-EXAMPLES           = '0.2'
+EXAMPLES           = '0.4'
 HOME_DIR = ENV['HOME']
 MAC_OR_LINUX = /linux|mac|darwin/ =~ RbConfig::CONFIG['host_os'] 
 

--- a/vendors/Rakefile
+++ b/vendors/Rakefile
@@ -77,5 +77,5 @@ task :copy_examples => file_name do
   end
   sh "rm -r #{HOME_DIR}/k9_samples" if File.exist? "#{HOME_DIR}/k9_samples"
   sh "cp -r samples4ruby-processing3-#{EXAMPLES} #{HOME_DIR}/k9_samples"  
-  sh "rm -r samples4ruby-processing3-#{EXAMPLES} #{HOME_DIR}/k9_samples"
+  sh "rm -r samples4ruby-processing3-#{EXAMPLES}"
 end  


### PR DESCRIPTION
Earlier versions are no longer relevant, and it's best to set stable now.