### PR TITLE
Radical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
-**v1.0.8** Exposed Constrain functionality for ArcBall, added literate prespektive method.
+**v1.0.8** Exposed Constrain functionality for ArcBall, added literate perspektive method. No longer trying to expose `sketchPath` variable (that was private since recent changes to vanilla processing), but provided an overloaded `sketchPath` method. Re-factor `MathTool` module class (jruby extension) to a simpler more correct form. Recommending the use of latest processing-3.1.1.
 
 **v1.0.7** Added tool to efficiently convert an Array of web colour Strings to and Array of color int (should be used by users of hype library, that uses of web strings in most of its examples). Update to use jruby-complete-9.1.0.0.
+
 **v1.0.6** Experimental support for an in sketch slider, examples now featuring Joshua Davis hype library.
+
 **v1.0.5** This version prefers processing-3.0.2 as the most recent version, and should be matched with oracle `jdk1.8.0_74+` for JavaFX fixes, or OpenJDK-8 and the latest OpenJFX otherwise stick with processing-3.0.1, which masks JavaFX inversion issue
 
 **v1.0.4** Using jruby-complete-9.0.5.0. Adding javadoc, with links to jruby.api and processing.api
+
 **v1.0.3** Build now using processing-3.0.1 core and matching video jars from maven central and pom.rb build file (polyglot maven), furthermore using maven-wrapper so maven version isn't even required see mvnw and mvwm.bat and .mvn/maven-wrapper.properties. The pom.xml is not needed but included for completness.
+
 **v1.0.2** Various cleanups, favoring SHA256 over SHA1 to check jruby-complete
 
 **v1.0.1** Using jruby-complete-9.0.4.0, features reworked extension build using maven
 
 **v1.0.0** Using jruby-complete-9.0.3.0 (no 9.0.2.0 owing to snafu at jruby.org) use github.io for home. Re-factor boids to use Vec3D, Vec2D and keyword arguments.
+
 **v0.9.0** Require processing-3.0.
 
 **v0.8.0** Require processing-3.0b7 and using jruby-9.0.1.0 replaced spec tests with minitest.

--- a/lib/jruby_art/app.rb
+++ b/lib/jruby_art/app.rb
@@ -112,11 +112,6 @@ module Processing
       run_sketch
     end
     
-    def self.start(options = {})
-      App.sketch_class.new
-    end
-
-
     def size(*args)
       w, h, mode = *args
       @width ||= w

--- a/lib/jruby_art/app.rb
+++ b/lib/jruby_art/app.rb
@@ -125,6 +125,11 @@ module Processing
       surface.set_title(title)
     end
 
+    def sketchPath(spath = nil)
+      return super() if spath.nil?
+      super(spath)
+    end
+
     def sketch_size(x, y)
       surface.set_size(x, y)
     end

--- a/lib/jruby_art/app.rb
+++ b/lib/jruby_art/app.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: false
 
 require 'java'
+# require 'jruby/core_ext'
 require_relative '../rpextras'
 require_relative '../jruby_art/helper_methods'
 require_relative '../jruby_art/helpers/aabb'
@@ -89,16 +90,15 @@ module Processing
     def library_loaded?(library_name)
       self.class.library_loaded?(library_name)
     end
-
+   
     # Since processing-3.0 you should prefer setting the sketch width and
     # height and renderer using the size method in the settings loop of the
     # sketch (as with vanilla processing) but is hidden see created java.
     # Options are no longer relevant, define post_initialize method to use
     # custom options (see Sandi Metz POODR)
 
-    def initialize(options = {})
+    def initialize
       super()
-      post_initialize(options) # for anyone wishing to pass options
       $app = self
       proxy_java_fields
       mix_proxy_into_inner_classes
@@ -111,6 +111,11 @@ module Processing
       # NB: this is the processing runSketch() method as used by processing.py
       run_sketch
     end
+    
+    def self.start(options = {})
+      App.sketch_class.new
+    end
+
 
     def size(*args)
       w, h, mode = *args
@@ -182,6 +187,7 @@ module Processing
         java_import format('processing.opengl.%s', klass)
       end
     end
+    # become_java!
   end # Processing::App
 
   # @HACK purists may prefer 'forwardable' to the use of Proxy

--- a/lib/jruby_art/helper_methods.rb
+++ b/lib/jruby_art/helper_methods.rb
@@ -119,7 +119,7 @@ module Processing
     # Proxy over a list of Java declared fields that have the same name as
     # some methods. Add to this list as needed.
     def proxy_java_fields
-      fields = %w(sketchPath key frameRate mousePressed keyPressed)
+      fields = %w(key frameRate mousePressed keyPressed)
       methods  = fields.map { |field| java_class.declared_field(field) }
       @declared_fields = Hash[fields.zip(methods)]
     end

--- a/lib/jruby_art/runners/base.rb
+++ b/lib/jruby_art/runners/base.rb
@@ -36,12 +36,12 @@ module Processing
     no_methods = source.match(/^[^#]*(def\s+setup|def\s+draw)/).nil?
     if wrapped
       load SKETCH_PATH
-      Processing::App.start unless $app
+      Processing::App.sketch_class.new unless $app
       return
     end
     code = no_methods ? format(NAKED_WRAP, source) : format(BARE_WRAP, source)
     Object.class_eval code, SKETCH_PATH, -1
-    Processing::App.start
+    Processing::App.sketch_class.new unless $app
   end
 
   # Read in the sketch source code. Needs to work both online and offline.

--- a/lib/jruby_art/runners/base.rb
+++ b/lib/jruby_art/runners/base.rb
@@ -36,12 +36,12 @@ module Processing
     no_methods = source.match(/^[^#]*(def\s+setup|def\s+draw)/).nil?
     if wrapped
       load SKETCH_PATH
-      Processing::App.sketch_class.new unless $app
+      Processing::App.start unless $app
       return
     end
     code = no_methods ? format(NAKED_WRAP, source) : format(BARE_WRAP, source)
     Object.class_eval code, SKETCH_PATH, -1
-    Processing::App.sketch_class.new
+    Processing::App.start
   end
 
   # Read in the sketch source code. Needs to work both online and offline.

--- a/lib/jruby_art/runners/base.rb
+++ b/lib/jruby_art/runners/base.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: false
 SKETCH_PATH ||= ARGV.shift
-SKETCH_ROOT ||= File.dirname(SKETCH_PATH)
+SKETCH_ROOT ||= File.absolute_path(File.dirname(SKETCH_PATH))
 
 # we can safely require app.rb as we are using a jruby runtime
 require_relative '../app'

--- a/src/monkstone/JRLibrary.java
+++ b/src/monkstone/JRLibrary.java
@@ -16,6 +16,7 @@ import monkstone.fastmath.Deglut;
 import monkstone.vecmath.vec2.Vec2;
 import monkstone.vecmath.vec3.Vec3;
 import org.jruby.Ruby;
+
 import org.jruby.runtime.load.Library;
 
 
@@ -30,9 +31,9 @@ public class JRLibrary implements Library{
      * @param runtime Ruby
      */
     public static void load(final Ruby runtime) {
-        MathTool.createMathTool(runtime);
-        Rarcball.createArcBall(runtime);
         Deglut.createDeglut(runtime);
+        MathToolModule.createMathToolModule(runtime);
+        Rarcball.createArcBall(runtime);        
         Vec2.createVec2(runtime);
         Vec3.createVec3(runtime);
     }

--- a/src/monkstone/MathToolModule.java
+++ b/src/monkstone/MathToolModule.java
@@ -11,12 +11,11 @@
 package monkstone;
 
 import org.jruby.Ruby;
-import org.jruby.RubyClass;
 import org.jruby.RubyFloat;
 import org.jruby.RubyModule;
-import org.jruby.RubyObject;
 import org.jruby.RubyRange;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -24,19 +23,17 @@ import org.jruby.runtime.builtin.IRubyObject;
  *
  * @author Martin Prout
  */
-
-public class MathTool extends RubyObject {
-
-    private static final long serialVersionUID = 4427564758225746633L;
-
-    /**
-     *
-     * @param runtime Ruby
-     */
-    public static void createMathTool(Ruby runtime) {
-        RubyModule processing = runtime.defineModule("Processing");
-        RubyModule module = processing.defineModuleUnder("MathTool");
-        module.defineAnnotatedMethods(MathTool.class);
+@JRubyModule(name = "MathTool") 
+public class MathToolModule {    
+    
+   /**
+    *
+    * @param runtime Ruby
+    */
+  
+    public static void createMathToolModule(Ruby runtime) {
+        RubyModule mtModule = runtime.defineModule("MathTool");
+        mtModule.defineAnnotatedMethods(MathToolModule.class);
     }
 
     /**
@@ -185,14 +182,5 @@ public class MathTool extends RubyObject {
         } else {
             return args[1];
         }
-    }
-    
-    /**
-     *
-     * @param runtime Ruby
-     * @param metaClass RubyClass
-     */
-    public MathTool(Ruby runtime, RubyClass metaClass) {
-        super(runtime, metaClass);
     }
 }

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -8,13 +8,13 @@ require_relative '../lib/jruby_art/helper_methods'
 Java::Monkstone::JRLibrary.new.load(JRuby.runtime, false)
 
 include Processing::HelperMethods
-include Processing::MathTool
+include MathTool
 
 Dir.chdir(File.dirname(__FILE__))
 
 class HelperMethodsTest < Minitest::Test
  def test_hex_color
-   col_double = 0.5
+    col_double = 0.5
     hexcolor = 0xFFCC6600
     dodgy_hexstring = '*56666'
     hexstring = '#CC6600'

--- a/test/k9_run_test.rb
+++ b/test/k9_run_test.rb
@@ -17,6 +17,17 @@ class Rp5Test < Minitest::Test
     assert_match(/ok/, out, 'Failed Basic Sketch')
   end
 
+  def test_sketch_path
+    out, _err_ = capture_io do
+      open('|../bin/k9 run sketches/sketch_path.rb', 'r') do |io|
+        while l = io.gets
+          puts(l.chop)
+        end
+      end
+    end
+    assert_match('/home/sid/radical/test', out, 'Failed Sketch Path Sketch')
+  end
+
   def test_on_top
     out, _err_ = capture_io do
       open('|../bin/k9 run sketches/on_top.rb', 'r') do |io|

--- a/test/math_tool_test.rb
+++ b/test/math_tool_test.rb
@@ -4,16 +4,17 @@ require 'minitest/autorun'
 require 'minitest/pride'
 
 require_relative '../lib/rpextras'
-require_relative '../lib/jruby_art/helper_methods'
+# require_relative '../lib/jruby_art/helper_methods'
 
 Java::Monkstone::JRLibrary.new.load(JRuby.runtime, false)
 
-include Processing::HelperMethods
-include Processing::MathTool
+# include Processing::HelperMethods
+
 
 Dir.chdir(File.dirname(__FILE__))
 
 class MathToolTest < Minitest::Test
+ include MathTool
  def test_map1d
     x = [0, 5, 7.5, 10]
     range1 = (0..10)
@@ -41,10 +42,10 @@ class MathToolTest < Minitest::Test
   def test_norm
     x = [10, 140, 210]
     start0, last0 = 30, 200
-    start1, last1 = 0, 200
+    start_int, last_int = 0, 200
     assert norm(x[0], start0, last0) == -0.11764705882352941, 'unclamped map'
-    assert norm(x[1], start1, last1) == 0.7, 'map to intermediate'
-    assert norm(x[2], start1, last1) == 1.05, 'unclamped map'
+    assert norm(x[1], start_int, last_int) == 0.7, 'map to intermediate'
+    assert norm(x[2], start_int, last_int) == 1.05, 'unclamped map'
   end
   
   def test_norm_strict
@@ -56,17 +57,22 @@ class MathToolTest < Minitest::Test
   def test_lerp # behaviour is deliberately different to processing which is unclamped
     x = [0.5, 0.8, 2.0]
     start0, last0 = 300, 200
-    start1, last1 = 0, 200
+    start_int, last_int = 0, 200
     assert lerp(start0, last0, x[0]) == 250, 'produces a intermediate value of a reversed range'
-    assert lerp(start1, last1, x[1]) == 160, 'lerps tp an intermediate value'
-    assert lerp(start1, last1, x[2]) == 200, 'lerps to the last value of a range'
+    assert lerp(start_int, last_int, x[1]) == 160, 'lerps tp an intermediate value'
+    assert lerp(start_int, last_int, x[2]) == 200, 'lerps to the last value of a range'
   end
   
   def test_constrain
-    x = [15, 2_500, -2_500]
-    start1, last1 = 0, 200
-    assert constrain(x[0], start1, last1) == 15
-    assert constrain(x[1], start1, last1) == 200
-    assert constrain(x[2], start1, last1) == 0
+    x_int = [15, 2_500, -2_500]
+    start_int, last_int = 0, 200
+    assert constrain(x_int[0], start_int, last_int) == 15
+    assert constrain(x_int[1], start_int, last_int) == 200
+    assert constrain(x_int[2], start_int, last_int) == 0
+    xf = [15.0, 2_500.0, -2_500.0]
+    startf, lastf = 0, 200.0
+    assert constrain(xf[0], startf, lastf) == 15.0
+    assert constrain(xf[1], startf, lastf) == 200.0
+    assert constrain(xf[2], startf, lastf) == 0.0
   end
 end

--- a/test/sketches/sketch_path.rb
+++ b/test/sketches/sketch_path.rb
@@ -1,0 +1,19 @@
+java_alias :background_int, :background, [Java::int]
+
+def setup
+  sketchPath(SKETCH_ROOT)
+  frame_rate(10)  
+  puts sketchPath
+end
+
+def draw
+  background_int 0
+  if frame_count == 3    
+    exit
+  end
+end
+
+def settings
+  size(300, 300)
+end
+


### PR DESCRIPTION
<!--
This is a simple template for filing JRubyArt issues.

Please help us help you by providing the information below.

Text inside XML comment tags will not be shown in your report.
-->

### Describe Proposed Changes

The `sketchPath` variable is now private since recent changes to vanilla-processing, we should try to make it available directly as vanilla processing has an overloaded getter/setter, this PR makes sure we can access both. The MathTool module has been simplified (java class is module using jruby annotations, and should not inherit from RubyObject).



