### PR TITLE
fix video binary folder macosx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**v1.3.1** Bump to jruby-9.1.9.0 which should be last before jruby-9.2.x.x series (ruby-2.4 here we come).
+**v1.3.1** The native binaries for the video library in MacOS are in the `macosx64` folder not the `macosx` this release should provide a quick fix. Note the library loader is in line for quite a major refactor in the near future, so this is a temporary fix.
 
 **v1.3.0** Not strictly semantic versioning in the sense that the significant internal refactoring of `launcher.rb` (and `sketch_writer.rb`) should not be evident to user. Bump to jruby-9.1.8.0 which should be last before jruby-9.2.x.x series (ruby-2.4 here we come).
 **v1.2.9** Grid method now in java (and corrected for step greater than 1). Update to processing-3.3. Update examples to 2.0, which features WOVNS examples that make use of `grid` method and in part caused me to look again a its implementation.

--- a/lib/jruby_art/library_loader.rb
+++ b/lib/jruby_art/library_loader.rb
@@ -82,14 +82,10 @@ module Processing
     end
 
     def get_platform_specific_library_paths(basename)
-      # for MacOS, but does this even work, or does Mac return '64'?
-      bits = 'universal'
+      bits = '64'
       if java.lang.System.getProperty('sun.arch.data.model') == '32' ||
          java.lang.System.getProperty('java.vm.name').index('32')
-        bits = '32'
-      elsif java.lang.System.getProperty('sun.arch.data.model') == '64' ||
-            java.lang.System.getProperty('java.vm.name').index('64')
-        bits = '64' unless platform =~ /macosx/
+        bits = '32' unless platform =~ /macosx/
       end
       [platform, platform + bits].map { |p| File.join(basename, p) }
     end


### PR DESCRIPTION
### Fixes

MacOS binaries should live in `macosx` folder, and it was assumed that they were, however the video library binaries lives in `macosx64` in the current version of processing.

### Describe Proposed Changes

Default is now `64` bit, however we were already looking in folders _sans_ bit as well so we should now be OK



