### PR TITLE
Library proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+**v1.4.0.pre** Extended LibraryProxy to allow implementing libraries to register mouseEvent(e) and keyEvent(e) with Sketch instance
+
 **v1.3.3** Update for processing-3.3.5. Simplify control_panel library (replacing `c.title = 'PaneTitle'` with `c.title('PaneTitle')`) also enable use of `block` with `button's`.
 
 **v1.3.2** Update for processing-3.3.3, jruby-9.1.12.0 and bump examples version to include glvideo library examples

--- a/lib/jruby_art/version.rb
+++ b/lib/jruby_art/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # A wrapper for version
 module JRubyArt
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.4.0.pre'.freeze
 end

--- a/lib/jruby_art/version.rb
+++ b/lib/jruby_art/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # A wrapper for version
 module JRubyArt
-  VERSION = '1.4.0.pre'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/library/library_proxy/library_proxy.rb
+++ b/library/library_proxy/library_proxy.rb
@@ -1,12 +1,12 @@
 java_import Java::MonkstoneCore::LibraryProxy
 
-
-# classes that inherit from Library are expected to implement
-# the abstract methods of monkstone.core.LibraryProxy
-# def pre...
-# def draw...
-# def post...
-# def keyPressed...
-# def mousePressed...
-# NOOP is fine...
+# classes that inherit from LibraryProxy are expected to implement
+# the abstract draw method of monkstone.core.LibraryProxy the other methods are
+# registered with PApplet instance in constructor ImplementingClass.new(app)
+#
+# def pre... NOOP can be overridden
+# def draw... Abstract Method should be implemented NOOP is OK
+# def post... NOOP can be overridden
+# def keyEvent(e)... NOOP can be overridden
+# def mouseEvent(e)... NOOP can be overridden
 # `app` can be called to get PApplet instance

--- a/library/library_proxy/library_proxy.rb
+++ b/library/library_proxy/library_proxy.rb
@@ -1,4 +1,6 @@
 java_import Java::MonkstoneCore::LibraryProxy
+java_import Java::ProcessingEvent::KeyEvent
+java_import Java::ProcessingEvent::MouseEvent
 
 # classes that inherit from LibraryProxy are expected to implement
 # the abstract draw method of monkstone.core.LibraryProxy the other methods are

--- a/pom.rb
+++ b/pom.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 project 'rp5extras', 'https://github.com/ruby-processing/JRubyArt' do
 
   model_version '4.0.0'
-  id 'ruby-processing:rp5extras', '1.4.0.pre'
+  id 'ruby-processing:rp5extras', '1.4.0'
   packaging 'jar'
 
   description 'rp5extras for JRubyArt'

--- a/pom.rb
+++ b/pom.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 project 'rp5extras', 'https://github.com/ruby-processing/JRubyArt' do
 
   model_version '4.0.0'
-  id 'ruby-processing:rp5extras', '1.3.3'
+  id 'ruby-processing:rp5extras', '1.4.0.pre'
   packaging 'jar'
 
   description 'rp5extras for JRubyArt'

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@ DO NOT MODIFIY - GENERATED CODE
   <modelVersion>4.0.0</modelVersion>
   <groupId>ruby-processing</groupId>
   <artifactId>rp5extras</artifactId>
-  <version>1.3.3</version>
+  <version>1.4.0.pre</version>
   <name>rp5extras</name>
   <description>rp5extras for JRubyArt</description>
   <url>https://github.com/ruby-processing/JRubyArt</url>
@@ -56,7 +56,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>org.processing</groupId>
       <artifactId>core</artifactId>
-      <version>3.3.4</version>
+      <version>3.3.5</version>
     </dependency>
     <dependency>
       <groupId>org.processing</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@ DO NOT MODIFIY - GENERATED CODE
   <modelVersion>4.0.0</modelVersion>
   <groupId>ruby-processing</groupId>
   <artifactId>rp5extras</artifactId>
-  <version>1.4.0.pre</version>
+  <version>1.4.0</version>
   <name>rp5extras</name>
   <description>rp5extras for JRubyArt</description>
   <url>https://github.com/ruby-processing/JRubyArt</url>

--- a/src/monkstone/core/LibraryProxy.java
+++ b/src/monkstone/core/LibraryProxy.java
@@ -2,106 +2,124 @@ package monkstone.core;
 
 import processing.core.PApplet;
 import static processing.core.PConstants.*;
+import processing.event.MouseEvent;
+import processing.event.KeyEvent;
 
 /**
- * The purpose of this class is to enable
- * access to processing pre, draw and post loops in
- * ruby-processing as a regular java library class.
- * Also included background, fill and stroke methods.
- * PConstants should also be available from static import
- * @author Martin Prout
- */
+* The purpose of this class is to enable
+* access to processing pre, draw and post loops in
+* ruby-processing as a regular java library class.
+* Also included background, fill and stroke methods.
+* PConstants should also be available from static import
+* @author Martin Prout
+*/
 public abstract class LibraryProxy {
 
-    private final PApplet app;
+  private final PApplet app;
 
-    /**
-     * Useful accessors
-     */
-    public int width, height;
+  /**
+  * Useful accessors
+  */
+  public int width, height;
 
-    /**
-     *
-     * @param app PApplet
-     */
-    public LibraryProxy(PApplet app) {
-        this.app = app;
-        this.width = app.width;
-        this.height = app.height;
-        setActive(true);
+  /**
+  *
+  * @param app PApplet
+  */
+  public LibraryProxy(PApplet app) {
+    this.app = app;
+    this.width = app.width;
+    this.height = app.height;
+    setActive(true);
+  }
+
+  /**
+  * Extending classes can override this, gives access to, by reflection,
+  * processing PApplet pre loop (called before draw)
+  */
+  public void pre(){}
+
+  /**
+  * Extending classes must implement this gives access to processing PApplet
+  * draw loop
+  */
+  public abstract void draw();
+
+  /**
+  * Extending classes can override this, gives access to, by reflection,
+  * processing PApplet post loop (called after draw)
+  */
+  public void post(){}
+
+  /**
+  * Extending classes can override this, gives access to, by reflection,
+  * processing PApplet post loop (called after draw)
+  */
+  public void keyEvent(KeyEvent e){}
+
+  /**
+  * Extending classes can override this, gives access to, by reflection,
+  * processing PApplet post loop (called after draw)
+  */
+  public void mouseEvent(MouseEvent e){}
+
+  /**
+  * Register or unregister reflection methods
+  * @param active
+  */
+  final void setActive(boolean active) {
+    if (active) {
+      this.app.registerMethod("pre", this);
+      this.app.registerMethod("draw", this);
+      this.app.registerMethod("post", this);
+      this.app.registerMethod("mouseEvent", this);
+      this.app.registerMethod("keyEvent", this);
+      this.app.registerMethod("dispose", this);
+    } else {
+      this.app.unregisterMethod("pre", this);
+      this.app.unregisterMethod("draw", this);
+      this.app.unregisterMethod("post", this);
+      this.app.unregisterMethod("mouseEvent", this);
+      this.app.unregisterMethod("keyEvent", this);
     }
+  }
 
-    /**
-     * Extending classes must implement this gives access to, by reflection,
-     * processing PApplet pre loop (called before draw)
-     */
-    public abstract void pre();
+  /**
+  * Simple signature for background hides need to call app
+  * @param col int
+  */
+  public void background(int col) {
+    this.app.background(col);
+  }
 
-    /**
-     * Extending classes must implement this gives access to processing PApplet
-     * draw loop
-     */
-    public abstract void draw();
+  /**
+  * Simple signature for fill hides need to call app
+  * @param col int
+  */
+  public void fill(int col) {
+    this.app.fill(col);
+  }
 
-    /**
-     * Extending classes must implement  this gives access to, by reflection,
-     * processing PApplet post loop (called after draw)
-     */
-    public abstract void post();
+  /**
+  * Simple signature for stroke hides need to call app
+  * @param col int
+  */
+  public void stroke(int col) {
+    this.app.stroke(col);
+  }
 
-    /**
-     * Register or unregister reflection methods
-     * @param active
-     */
-    final void setActive(boolean active) {
-        if (active) {
-            this.app.registerMethod("pre", this);
-            this.app.registerMethod("draw", this);
-            this.app.registerMethod("post", this);
-            this.app.registerMethod("dispose", this);
-        } else {
-            this.app.unregisterMethod("pre", this);
-            this.app.unregisterMethod("draw", this);
-            this.app.unregisterMethod("post", this);
-        }
-    }
+  /**
+  * Access applet if we must
+  * @return applet PApplet
+  */
+  public PApplet app() {
+    return this.app;
+  }
 
-    /**
-     * Simple signature for background hides need to call app
-     * @param col int
-     */
-    public void background(int col) {
-        this.app.background(col);
-    }
-
-    /**
-     * Simple signature for fill hides need to call app
-     * @param col int
-     */
-    public void fill(int col) {
-        this.app.fill(col);
-    }
-
-    /**
-     * Simple signature for stroke hides need to call app
-     * @param col int
-     */
-    public void stroke(int col) {
-        this.app.stroke(col);
-    }
-
-    /**
-     * Access applet if we must
-     * @return applet PApplet
-     */
-    public PApplet app() {
-        return this.app;
-    }
-
-    /**
-     * required for processing
-     */
-    public void dispose() {
-        setActive(false);
-    }
+  /**
+  * required for processing
+  */
+  public void dispose() {
+    setActive(false);
+  }
 }

--- a/vendors/Rakefile
+++ b/vendors/Rakefile
@@ -11,7 +11,7 @@ EOS
 
 JRUBYC_VERSION     = '9.1.12.0'
 
-EXAMPLES           = '2.3'
+EXAMPLES           = '2.4'
 HOME_DIR = ENV['HOME']
 MAC_OR_LINUX = /linux|mac|darwin/ =~ RbConfig::CONFIG['host_os']
 


### PR DESCRIPTION
The purpose of this change is give full access to vanilla-processing "library methods", whilst hiding the nastiness of java reflection from the the ruby developer. Apart from the need to use camel case `mouseEvent` and `keyEvent`. Does require a knowledge of processing event package.



