### PR TITLE
Duck type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+**v1.4.5** Vec2D and Vec3D now support `copy` constructor where the original can be a duck-type. Further the only requirement is that the duck-type responds to `:x`, and `:y` by returning a `float` or `fixnum` thus Vec2D can be promoted to Vec3D (where `z = 0`), or more usually some other Vector or Point class can be used as the original. A VectorUtils library has been implemented in see examples for usage.
 
 **v1.4.4** Bump up to JRubyComplete-9.1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**v1.4.5** Vec2D and Vec3D now support `copy` constructor where the original can be a duck-type. Further the only requirement is that the duck-type responds to `:x`, and `:y` by returning a `float` or `fixnum` thus Vec2D can be promoted to Vec3D (where `z = 0`), or more usually some other Vector or Point class can be used as the original. A VectorUtils library has been implemented in see examples for usage.
+**v1.4.5** Vec2D and Vec3D now support `copy` constructor where the original can be a duck-type. Further the only requirement is that the duck-type responds to `:x`, and `:y` by returning a `float` or `fixnum` thus Vec2D can be promoted to Vec3D (where `z = 0`), or more usually some other Vector or Point class can be used as the original. A VectorUtils library has been implemented, see examples for usage.
 
 **v1.4.4** Bump up to JRubyComplete-9.1.15.0
 

--- a/lib/jruby_art/version.rb
+++ b/lib/jruby_art/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # A wrapper for version
 module JRubyArt
-  VERSION = '1.4.4'.freeze
+  VERSION = '1.4.5'.freeze
 end

--- a/library/vector_utils/vector_utils.rb
+++ b/library/vector_utils/vector_utils.rb
@@ -1,0 +1,69 @@
+PHI ||= (1 + Math.sqrt(5)) / 2 # golden ratio
+GA = PHI * 2 * Math::PI # golden angle
+
+# Useful Vector Utiliies
+module VectorUtil
+  def self.rotate_vec2d(vectors: [], angle: 0)
+    vectors.map { |vector| vector.rotate(angle) }
+  end
+
+  def self.vogel_layout(number:, node_size:)
+    (0..number).map do |i|
+      r = Math.sqrt(i)
+      theta = i * ((2 * Math::PI) / (PHI * PHI))
+      x = Math.cos(theta) * r * node_size
+      y = Math.sin(theta) * r * node_size
+      Vec2D.new(x, y)
+    end
+  end
+
+  def self.fibonacci_sphere(number:, radius:)
+    (0..number).map do |i|
+      lon = GA * i
+      lon /= 2 * Math::PI
+      lon -= lon.floor
+      lon *= 2 * Math::PI
+      lon -= 2 * Math::PI if lon > Math::PI
+      lat = Math.asin(-1 + 2 * i / number.to_f)
+      x = radius * Math.cos(lat) * Math.cos(lon)
+      y = radius * Math.cos(lat) * Math.sin(lon)
+      z = radius * Math.sin(lat)
+      Vec3D.new(x, y, z)
+    end
+  end
+
+  def self.spiral_layout(number:, radius:, resolution:, spacing:, inc:)
+    n = 0
+    angle = nil
+    (0..number).map do
+      angle = n * resolution
+      n += inc
+      radius -= angle * spacing
+      x = Math.cos(angle) * radius
+      y = Math.sin(angle) * radius
+      Vec2D.new(x, y)
+    end
+  end
+
+  def self.cartesian_to_polar(vec:)
+    res = Vec3D.new(vec.mag, 0, 0)
+    return Vec3D.new unless res.x > 0
+    res.y = -Math.atan2(vec.z, vec.x)
+    res.z = Math.asin(vec.y / res.x)
+    res
+  end
+
+  def self.to_cartesian(lat:, long:, radius:)
+    latitude = lat
+    longitude = long
+    x = radius * Math.cos(latitude) * Math.cos(longitude)
+    y = radius * Math.cos(latitude) * Math.sin(longitude)
+    z = radius * Math.sin(latitude)
+    Vec3D.new(x, y, z)
+  end
+
+  def self.polar_to_cartesian(vec:)
+    return Vec3D.new if vec.mag <= 0
+    Vec3D.new(Math.asin(vec.y / vec.mag), vec.mag, -Math.atan2(vec.z, vec.x))
+  end
+end

--- a/pom.rb
+++ b/pom.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 project 'rp5extras', 'https://github.com/ruby-processing/JRubyArt' do
 
   model_version '4.0.0'
-  id 'ruby-processing:rp5extras', '1.4.4'
+  id 'ruby-processing:rp5extras', '1.4.5'
   packaging 'jar'
 
   description 'rp5extras for JRubyArt'

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -88,11 +88,19 @@ public class Vec2 extends RubyObject {
     }
 
     void init(ThreadContext context, IRubyObject[] args) {
-        if (Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 2) == 2) {
-            jx = (args[0] instanceof RubyFloat)
-                    ? ((RubyFloat) args[0]).getValue() : ((RubyFixnum) args[0]).getDoubleValue();
-            jy = (args[1] instanceof RubyFloat)
-                    ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+        int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 2);
+        if (count == 2) {
+            jx = (args[0] instanceof RubyFloat) ? ((RubyFloat) args[0]).getValue() : ((RubyFixnum) args[0]).getDoubleValue();
+            jy = (args[1] instanceof RubyFloat) ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+        }   // allow ruby ducktyping in constructor
+        if (count == 1) {
+            if (!(args[0].respondsTo("x"))) {
+                throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");
+            }
+            jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
+            jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
         }
     }
 
@@ -102,7 +110,6 @@ public class Vec2 extends RubyObject {
      * @return x IRubyObject
      */
     @JRubyMethod(name = "x")
-
     public IRubyObject getX(ThreadContext context) {
         return context.runtime.newFloat(jx);
     }
@@ -113,7 +120,6 @@ public class Vec2 extends RubyObject {
      * @return y IRubyObject
      */
     @JRubyMethod(name = "y")
-
     public IRubyObject getY(ThreadContext context) {
         return context.runtime.newFloat(jy);
     }
@@ -148,7 +154,6 @@ public class Vec2 extends RubyObject {
      * @return value float
      */
     @JRubyMethod(name = "[]=")
-
     public IRubyObject aset(ThreadContext context, IRubyObject key, IRubyObject value) {
         Ruby runtime = context.runtime;
         if (key instanceof RubySymbol) {
@@ -172,7 +177,6 @@ public class Vec2 extends RubyObject {
      * @return x IRubyObject
      */
     @JRubyMethod(name = "x=")
-
     public IRubyObject setX(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFloat) {
             jx = ((RubyFloat) other).getValue();
@@ -189,7 +193,6 @@ public class Vec2 extends RubyObject {
      * @return y IRubyObject
      */
     @JRubyMethod(name = "y=")
-
     public IRubyObject setY(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFloat) {
             jy = ((RubyFloat) other).getValue();
@@ -206,7 +209,6 @@ public class Vec2 extends RubyObject {
      * @return distance float
      */
     @JRubyMethod(name = "dist", required = 1)
-
     public IRubyObject dist(ThreadContext context, IRubyObject other) {
         Vec2 b = null;
         Ruby runtime = context.runtime;
@@ -226,7 +228,6 @@ public class Vec2 extends RubyObject {
      * @return cross product IRubyObject
      */
     @JRubyMethod(name = "cross", required = 1)
-
     public IRubyObject cross(ThreadContext context, IRubyObject other) {
         Vec2 b = null;
         Ruby runtime = context.runtime;
@@ -245,7 +246,6 @@ public class Vec2 extends RubyObject {
      * @return dot product IRubyObject
      */
     @JRubyMethod(name = "dot", required = 1)
-
     public IRubyObject dot(ThreadContext context, IRubyObject other) {
         Vec2 b = null;
         Ruby runtime = context.runtime;
@@ -264,7 +264,6 @@ public class Vec2 extends RubyObject {
      * @return new Vec2D object (ruby)
      */
     @JRubyMethod(name = "+", required = 1)
-
     public IRubyObject op_plus(ThreadContext context, IRubyObject other) {
         Vec2 b = null;
         Ruby runtime = context.runtime;
@@ -285,7 +284,6 @@ public class Vec2 extends RubyObject {
      * @return new Vec2D object (ruby)
      */
     @JRubyMethod(name = "-", required = 1)
-
     public IRubyObject op_minus(ThreadContext context, IRubyObject other) {
         Vec2 b = null;
         Ruby runtime = context.runtime;
@@ -306,7 +304,6 @@ public class Vec2 extends RubyObject {
      * @return new Vec2D object (ruby)
      */
     @JRubyMethod(name = "*")
-
     public IRubyObject op_mul(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         double scalar = (other instanceof RubyFloat)
@@ -323,7 +320,6 @@ public class Vec2 extends RubyObject {
      * @return new Vec2D object (ruby)
      */
     @JRubyMethod(name = "/", required = 1)
-
     public IRubyObject op_div(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         double scalar = (other instanceof RubyFloat)
@@ -352,7 +348,6 @@ public class Vec2 extends RubyObject {
      * @return magnitude IRubyObject
      */
     @JRubyMethod(name = "mag")
-
     public IRubyObject mag(ThreadContext context) {
         double result = 0;
         if (Math.abs(jx) > EPSILON && Math.abs(jy) > EPSILON) {
@@ -378,7 +373,6 @@ public class Vec2 extends RubyObject {
      * @return magnitude IRubyObject
      */
     @JRubyMethod(name = "set_mag")
-
     public IRubyObject set_mag(ThreadContext context, IRubyObject scalar, Block block) {
         double new_mag = (Double) scalar.toJava(Double.class);
         if (block.isGiven()) {
@@ -410,7 +404,6 @@ public class Vec2 extends RubyObject {
      * @return this as a ruby object
      */
     @JRubyMethod(name = "normalize!")
-
     public IRubyObject normalize_bang(ThreadContext context) {
         double mag = 0;
         if (Math.abs(jx) > EPSILON && Math.abs(jy) > EPSILON) {
@@ -436,7 +429,6 @@ public class Vec2 extends RubyObject {
      * @return new normalized Vec3D object (ruby)
      */
     @JRubyMethod(name = "normalize")
-
     public IRubyObject normalize(ThreadContext context) {
         double mag = 0;
         Ruby runtime = context.runtime;
@@ -573,7 +565,6 @@ public class Vec2 extends RubyObject {
      * @return angle IRubyObject in radians
      */
     @JRubyMethod(name = "angle_between")
-
     public IRubyObject angleBetween(ThreadContext context, IRubyObject other) {
         Vec2 vec = null;
         Ruby runtime = context.runtime;
@@ -591,7 +582,6 @@ public class Vec2 extends RubyObject {
      * @return IRubyObject copy
      */
     @JRubyMethod(name = {"copy", "dup"})
-
     public IRubyObject copy(ThreadContext context) {
         Ruby runtime = context.runtime;
         return Vec2.rbNew(context, this.getMetaClass(), new IRubyObject[]{
@@ -605,7 +595,6 @@ public class Vec2 extends RubyObject {
      * @return IRubyObject array of float
      */
     @JRubyMethod(name = "to_a")
-
     public IRubyObject toArray(ThreadContext context) {
         Ruby runtime = context.runtime;
         return RubyArray.newArray(runtime, new IRubyObject[]{
@@ -621,7 +610,6 @@ public class Vec2 extends RubyObject {
      * @param object IRubyObject vertex renderer
      */
     @JRubyMethod(name = "to_vertex")
-
     public void toVertex(ThreadContext context, IRubyObject object) {
         JRender renderer = (JRender) object.toJava(JRender.class);
         renderer.vertex(jx, jy);
@@ -635,7 +623,6 @@ public class Vec2 extends RubyObject {
      * @param object IRubyObject vertex renderer
      */
     @JRubyMethod(name = "to_curve_vertex")
-
     public void toCurveVertex(ThreadContext context, IRubyObject object) {
         JRender renderer = (JRender) object.toJava(JRender.class);
         renderer.curveVertex(jx, jy);
@@ -648,7 +635,6 @@ public class Vec2 extends RubyObject {
      * @return IRubyObject to_s
      */
     @JRubyMethod(name = {"to_s", "inspect"})
-
     public IRubyObject to_s(ThreadContext context) {
         return context.runtime.newString(String.format("Vec2D(x = %4.4f, y = %4.4f)", jx, jy));
     }
@@ -716,7 +702,6 @@ public class Vec2 extends RubyObject {
      * @return result IRubyObject as boolean
      */
     @JRubyMethod(name = "==", required = 1)
-
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;

--- a/src/monkstone/vecmath/vec3/Vec3.java
+++ b/src/monkstone/vecmath/vec3/Vec3.java
@@ -92,6 +92,19 @@ public final class Vec3 extends RubyObject {
         if (count == 3) {
             jz = (args[2] instanceof RubyFloat)
                     ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
+        } // allow ruby ducktyping in constructor
+        if (count == 1) {
+            if (!(args[0].respondsTo("x"))) {
+                throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");
+            }
+            jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
+            jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
+            if (!(args[0].respondsTo("z"))) {
+                return;
+            } // allow promotion from 2D to 3D, sets jz = 0
+            jz = ((args[0].callMethod(context, "z")) instanceof RubyFloat) ? ((RubyFloat) args[0].callMethod(context, "z")).getValue() : ((RubyFixnum) args[0].callMethod(context, "z")).getDoubleValue();
         }
     }
 
@@ -101,7 +114,6 @@ public final class Vec3 extends RubyObject {
      * @return x IRubyObject
      */
     @JRubyMethod(name = "x")
-
     public IRubyObject getX(ThreadContext context) {
         return context.runtime.newFloat(jx);
     }
@@ -112,7 +124,6 @@ public final class Vec3 extends RubyObject {
      * @return y IRubyObject
      */
     @JRubyMethod(name = "y")
-
     public IRubyObject getY(ThreadContext context) {
         return context.runtime.newFloat(jy);
     }
@@ -134,7 +145,6 @@ public final class Vec3 extends RubyObject {
      * @return x IRubyObject
      */
     @JRubyMethod(name = "x=")
-
     public IRubyObject setX(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFloat) {
             jx = ((RubyFloat) other).getValue();
@@ -151,7 +161,6 @@ public final class Vec3 extends RubyObject {
      * @return y IRubyObject
      */
     @JRubyMethod(name = "y=")
-
     public IRubyObject setY(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFloat) {
             jy = ((RubyFloat) other).getValue();
@@ -184,7 +193,6 @@ public final class Vec3 extends RubyObject {
      * @return value float
      */
     @JRubyMethod(name = "[]", required = 1)
-
     public IRubyObject aref(ThreadContext context, IRubyObject key) {
         Ruby runtime = context.runtime;
         if (key instanceof RubySymbol) {
@@ -209,7 +217,6 @@ public final class Vec3 extends RubyObject {
      * @return value float
      */
     @JRubyMethod(name = "[]=")
-
     public IRubyObject aset(ThreadContext context, IRubyObject key, IRubyObject value) {
         Ruby runtime = context.runtime;
         if (key instanceof RubySymbol) {
@@ -238,7 +245,6 @@ public final class Vec3 extends RubyObject {
      * @return distance float
      */
     @JRubyMethod(name = "dist", required = 1)
-
     public IRubyObject dist(ThreadContext context, IRubyObject other) {
         Vec3 b = null;
         if (other instanceof Vec3) {
@@ -257,7 +263,6 @@ public final class Vec3 extends RubyObject {
      * @return distance squared float
      */
     @JRubyMethod(name = "dist_squared", required = 1)
-
     public IRubyObject dist_squared(ThreadContext context, IRubyObject other) {
         Vec3 b = null;
         if (other instanceof Vec3) {
@@ -277,7 +282,6 @@ public final class Vec3 extends RubyObject {
      * @return cross product IRubyObject
      */
     @JRubyMethod(name = "cross", required = 1)
-
     public IRubyObject cross(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         Vec3 vec = null;
@@ -301,7 +305,6 @@ public final class Vec3 extends RubyObject {
      * @return dot product IRubyObject
      */
     @JRubyMethod(name = "dot", required = 1)
-
     public IRubyObject dot(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         Vec3 b = null;
@@ -320,7 +323,6 @@ public final class Vec3 extends RubyObject {
      * @return new Vec3 object (ruby)
      */
     @JRubyMethod(name = "+", required = 1)
-
     public IRubyObject op_add(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         Vec3 b = (Vec3) other.toJava(Vec3.class);
@@ -337,7 +339,6 @@ public final class Vec3 extends RubyObject {
      * @return new Vec3 object (ruby)
      */
     @JRubyMethod(name = "-")
-
     public IRubyObject op_sub(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         Vec3 b = null;
@@ -359,7 +360,6 @@ public final class Vec3 extends RubyObject {
      * @return new Vec3 object (ruby)
      */
     @JRubyMethod(name = "*", required = 1)
-
     public IRubyObject op_mul(ThreadContext context, IRubyObject scalar) {
         Ruby runtime = context.runtime;
         double multi = (scalar instanceof RubyFloat)
@@ -377,7 +377,6 @@ public final class Vec3 extends RubyObject {
      * @return new Vec3 object (ruby)
      */
     @JRubyMethod(name = "/", required = 1)
-
     public IRubyObject op_div(ThreadContext context, IRubyObject scalar) {
         Ruby runtime = context.runtime;
         double divisor = (scalar instanceof RubyFloat)
@@ -397,7 +396,6 @@ public final class Vec3 extends RubyObject {
      * @return magnitude squared IRubyObject
      */
     @JRubyMethod(name = "mag_squared")
-
     public IRubyObject mag_squared(ThreadContext context) {
         return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
     }
@@ -408,7 +406,6 @@ public final class Vec3 extends RubyObject {
      * @return magnitude IRubyObject
      */
     @JRubyMethod(name = "mag")
-
     public IRubyObject mag(ThreadContext context) {
         return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
     }
@@ -423,7 +420,6 @@ public final class Vec3 extends RubyObject {
      * @return magnitude IRubyObject
      */
     @JRubyMethod(name = "set_mag")
-
     public IRubyObject set_mag(ThreadContext context, IRubyObject scalar, Block block) {
         if (block.isGiven()) {
             if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
@@ -447,7 +443,6 @@ public final class Vec3 extends RubyObject {
      * @return this as a ruby object
      */
     @JRubyMethod(name = "normalize!")
-
     public IRubyObject normalize_bang(ThreadContext context) {
         if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
             return this;
@@ -465,7 +460,6 @@ public final class Vec3 extends RubyObject {
      * @return new normalized Vec3D object (ruby)
      */
     @JRubyMethod(name = "normalize")
-
     public IRubyObject normalize(ThreadContext context) {
         Ruby runtime = context.runtime;
         double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
@@ -489,14 +483,12 @@ public final class Vec3 extends RubyObject {
      * @return new random Vec3D object (ruby)
      */
     @JRubyMethod(name = "random", meta = true)
-
     public static IRubyObject random_direction(ThreadContext context, IRubyObject klazz) {
         Ruby runtime = context.runtime;
         double angle = Math.random() * Math.PI * 2;
         double vz = Math.random() * 2 - 1;
         double vx = Math.sqrt(1 - vz * vz) * Math.cos(angle);
         double vy = Math.sqrt(1 - vz * vz) * Math.sin(angle);
-
         return Vec3.rbNew(context, klazz, new IRubyObject[]{
             runtime.newFloat(vx),
             runtime.newFloat(vy),
@@ -510,7 +502,6 @@ public final class Vec3 extends RubyObject {
      * @return angle IRubyObject in radians
      */
     @JRubyMethod(name = "angle_between")
-
     public IRubyObject angleBetween(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         Vec3 vec = (Vec3) other.toJava(Vec3.class);
@@ -522,7 +513,6 @@ public final class Vec3 extends RubyObject {
         if (vec.jx == 0 && vec.jy == 0 && vec.jz == 0) {
             return runtime.newFloat(0.0);
         }
-
         double dot = jx * vec.jx + jy * vec.jy + jz * vec.jz;
         double v1mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
         double v2mag = Math.sqrt(vec.jx * vec.jx + vec.jy * vec.jy + vec.jz * vec.jz);
@@ -542,7 +532,6 @@ public final class Vec3 extends RubyObject {
      * @return IRubyObject copy
      */
     @JRubyMethod(name = {"copy", "dup"})
-
     public IRubyObject copy(ThreadContext context) {
         Ruby runtime = context.runtime;
         return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
@@ -557,7 +546,6 @@ public final class Vec3 extends RubyObject {
      * @return IRubyObject array of float
      */
     @JRubyMethod(name = "to_a")
-
     public IRubyObject toArray(ThreadContext context) {
         Ruby runtime = context.runtime;
         return RubyArray.newArray(context.runtime, new IRubyObject[]{
@@ -573,7 +561,6 @@ public final class Vec3 extends RubyObject {
      * @param object IRubyObject vertex renderer
      */
     @JRubyMethod(name = "to_vertex")
-
     public void toVertex(ThreadContext context, IRubyObject object) {
         JRender renderer = (JRender) object.toJava(JRender.class);
         renderer.vertex(jx, jy, jz);
@@ -586,7 +573,6 @@ public final class Vec3 extends RubyObject {
      * @param object IRubyObject vertex renderer
      */
     @JRubyMethod(name = "to_curve_vertex")
-
     public void toCurveVertex(ThreadContext context, IRubyObject object) {
         JRender renderer = (JRender) object.toJava(JRender.class);
         renderer.curveVertex(jx, jy, jz);
@@ -599,7 +585,6 @@ public final class Vec3 extends RubyObject {
      * @param args IRubyObject[]
      */
     @JRubyMethod(name = "to_vertex_uv", rest = true)
-
     public void toVertexUV(ThreadContext context, IRubyObject[] args) {
         int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 3);
         double u = 0;
@@ -626,7 +611,6 @@ public final class Vec3 extends RubyObject {
      * @param object IRubyObject vertex renderer
      */
     @JRubyMethod(name = "to_normal")
-
     public void toNormal(ThreadContext context, IRubyObject object) {
         JRender renderer = (JRender) object.toJava(JRender.class);
         renderer.normal(jx, jy, jz);
@@ -639,7 +623,6 @@ public final class Vec3 extends RubyObject {
      * @return IRubyObject to_s
      */
     @JRubyMethod(name = {"to_s", "inspect"})
-
     public IRubyObject to_s(ThreadContext context) {
         return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
     }
@@ -688,7 +671,6 @@ public final class Vec3 extends RubyObject {
      * @return result IRubyObject as boolean
      */
     @JRubyMethod(name = "eql?", required = 1)
-
     public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
         if (other == this) {
@@ -713,7 +695,6 @@ public final class Vec3 extends RubyObject {
      * @return result IRubyObject as boolean
      */
     @JRubyMethod(name = "==", required = 1)
-
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;

--- a/test/aabb_spec_test.rb
+++ b/test/aabb_spec_test.rb
@@ -1,8 +1,4 @@
-gem 'minitest'      # don't use bundled minitest
-require 'java'
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/rpextras'
 require_relative '../lib/jruby_art/helpers/aabb'
 

--- a/test/create_test.rb
+++ b/test/create_test.rb
@@ -1,8 +1,4 @@
-gem 'minitest' # don't use bundled minitest
-require 'minitest/autorun'
-require 'minitest/pride'
-
-
+require_relative 'test_helper'
 require_relative '../lib/jruby_art/creators/sketch_writer'
 
 EMACS = <<~CODE

--- a/test/deglut_spec_test.rb
+++ b/test/deglut_spec_test.rb
@@ -1,8 +1,4 @@
-gem 'minitest' # don't use bundled minitest
-require 'java'
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/rpextras'
 
 Java::Monkstone::JRLibrary.new.load(JRuby.runtime, false)

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -1,8 +1,4 @@
-gem 'minitest'      # don't use bundled minitest
-require 'java'
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/jruby_art/helper_methods'
 
 Java::Monkstone::JRLibrary.new.load(JRuby.runtime, false)

--- a/test/math_tool_test.rb
+++ b/test/math_tool_test.rb
@@ -1,8 +1,4 @@
-gem 'minitest'      # don't use bundled minitest
-require 'java'
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/rpextras'
 # require_relative '../lib/jruby_art/helper_methods'
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,8 +1,4 @@
-gem 'minitest'      # don't use bundled minitest
-require 'minitest/autorun'
-require 'minitest/pride'
-
-require_relative '../lib/jruby_art/command'
+require_relative 'test_helper'
 
 JAVA = %w(java -Xmx512 -Xms1G -cp /home/tux/JRubyArt/lib/ruby/jruby-complete.jar org.jruby.Main watch)
 JRUBY = %w(jruby -J-Xmx512 -J-Xms1G watch)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+gem 'minitest'      # don't use bundled minitest
+require 'java'
+require 'minitest/autorun'
+require 'minitest/pride'

--- a/test/test_java_args.rb
+++ b/test/test_java_args.rb
@@ -1,7 +1,4 @@
-gem 'minitest'      # don't use bundled minitest
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/jruby_art/java_opts'
 
 JAVA = %w(-Xmx512 -Xms1G)

--- a/test/test_map1d.rb
+++ b/test/test_map1d.rb
@@ -1,8 +1,4 @@
-gem 'minitest' # don't use bundled minitest
-require 'java'
-require 'minitest/autorun'
-require 'minitest/pride'
-
+require_relative 'test_helper'
 require_relative '../lib/rpextras'
 require_relative '../lib/jruby_art/helper_methods'
 


### PR DESCRIPTION
### The Vec2D and Vec3D classes are implemented in java

There is no copy constructor, or duck-type constructor

### The Proposed Changes create copy and duck-type constructor

The advantages of the proposed implementation is that the duck type need ony support `:x` and `:y` methods thus Vec2D instances could be promoted to Vec3D. Or similary with and suitable point class, or alternative vector.
 
### Enhanced vector cabilities via ruby library.
Similar to [DawesomeToolkit](http://cloud.brendandawes.com/dawesometoolkit/)



  