### PR TITLE
add body margin

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -19,6 +19,7 @@ body {
     line-height: $base-line-height;
     font-weight: 300;
     color: $text-color;
+    margin: 10px
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
Add body margin. Currently site paragraphs run right up against the left edge of the screen, making it a bit hard to read.

<!--
This is a simple template for filing JRubyArt issues.

Please help us help you by providing the information below.

Text inside XML comment tags will not be shown in your report.
-->

### Fixes

Some Issue

### Describe Proposed Changes



